### PR TITLE
2023 event edit + SC update

### DIFF
--- a/docs/events.html
+++ b/docs/events.html
@@ -34,7 +34,7 @@ layout: main
 <h3><a href="events/jedi-2023-annual-meeting.html#panel2">Panel 2: Transparency in peer review: challenges and opportunities</a></h3>
 <p><i>Explore the evolving landscape of peer review with the panelists as they discuss challenges and opportunities related to transparency, open reviewer identities, open content in reviews, new ways to provide post-publication evaluations of scholarly manuscripts, and more.</i></p>
 
-<p><a href="events/jedi-2023-annual-meeting.html">Click here to register and read more information on the panels!</a></p>
+<p><a href="events/jedi-2023-annual-meeting.html">Click here for the recordings and more information on the panels!</a></p>
   <br>
   <hr>
 	<h2>May the force be with you: Resources to help journal editors advance their fields </h2>

--- a/docs/events/jedi-2023-annual-meeting.html
+++ b/docs/events/jedi-2023-annual-meeting.html
@@ -22,6 +22,13 @@ layout: main
             flex: 1;
 
         }
+        
+        hr {
+      border: 0;
+      height: 1px;
+      width: 50%;
+      background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+      }  
     </style>
 </head>
 
@@ -37,16 +44,18 @@ layout: main
 			<ul>
 				<li><h3><a href="#panel1">Panel 1: Experiences with Correcting the Scientific Record</a></h3></li>
 				<p>Join a group of experts as they delve into the practical aspects of rectifying or withdrawing publications, offering valuable experiences and perspectives on the motivations and complexities involved.</p>
+				<p><b>Video recording:</b> <a href="https://www.youtube.com/watch?v=72jHzR432hQ">https://www.youtube.com/watch?v=72jHzR432hQ</a> </p>
+				
 				<li><h3><a href="#panel2">Panel 2: Transparency & Innovation in Peer Review</a></h3></li>
 				<p>Explore the evolving landscape of peer review with the panelists as they discuss challenges and opportunities related to transparency, open reviewer identities, open content in reviews, new ways to provide post-publication evaluations of scholarly manuscripts, and more.</p>
+				<p><b>Video recording:</b> <a href="https://www.youtube.com/watch?v=KL8trP0mVJ4">https://www.youtube.com/watch?v=KL8trP0mVJ4</a></p>
+
 			</ul>
-      <a href="https://forms.gle/SpJh7dtPqNaterGFA" class="button">Register for the Event</a>
-
+				
 				<br>
 				<br>
-				<br>
-
-<h2 id="panel1">Panel 1: Experiences with Correcting the Scientific Record</h2>
+        <hr>
+<h2 id="panel1"><a href="https://www.youtube.com/watch?v=72jHzR432hQ" style="color:#004851;" target = "_blank">Panel 1: Experiences with Correcting the Scientific Record</a></h2>
 <p><b>Panel duration:</b> 90 minutes </p>
 <p><b>Date:</b> November 15 / 16</p>
 <p><b>Start times:</b> 9am Melbourne (Nov 16), 11am Auckland (Nov 16), 2pm US Pacific (Nov 15), 5pm US Eastern (Nov 15) [<a href="https://savvytime.com/converter/australia-melbourne-to-new-zealand-auckland-ca-los-angeles-il-chicago-ny-new-york-city/nov-16-2023/9am" target = "_blank">See in other time zones</a>]</p>
@@ -90,9 +99,9 @@ layout: main
         </div>
     </div>
 
+    <hr>
 
-
-<h2 id="panel2">Panel 2: Transparency in peer review: challenges and opportunities</h2>
+<h2 id="panel2"><a href="https://www.youtube.com/watch?v=KL8trP0mVJ4" style="color:#004851;"  target = "_blank">Panel 2: Transparency in peer review: challenges and opportunities</a></h2>
 <p><b>Panel duration:</b> 90 minutes </p>
 <p><b>Date:</b> November 15 / 16</p>
 <p><b>Start times:</b> 8am US Pacific, 11am US Eastern, 1pm São Paulo, 4pm London, 5pm Amsterdam (Nov 16) [<a href="https://savvytime.com/converter/ca-los-angeles-to-ny-new-york-city-brazil-sao-paulo-united-kingdom-london-netherlands-amsterdam/nov-16-2023/8am" target = "_blank">See in other time zones</a>]</p>
@@ -135,7 +144,4 @@ layout: main
             
         </div>
     </div>
-<div>
-    <a href="https://forms.gle/SpJh7dtPqNaterGFA" class="button">Register for the Event</a>
-</div>
 

--- a/docs/governance.html
+++ b/docs/governance.html
@@ -46,7 +46,7 @@ layout: main
 <li>Rick Gilmore, Databrary, Pennsylvania State University</li>
 <li>Sebastian Karcher, Qualitative Data Repository, Syracuse University</li>
 <li>Simine Vazire, Collabra, University of Melbourne</li>
-<li>Stefano Iacus, Dataverse Project, Harvard University</li>
+<li>Sonia Barbosa, Dataverse Project, Harvard University</li>
 <li>Thomas Nelson Laird, The Review of Higher Education, Indiana University Bloomington</li>
 <li>Thu-Mai Christian, Odum Institute for Research in Social Science, University of North Carolina at Chapel Hill</li>
 <li>Volkan Topalli, Criminology, Georgia State University</li>


### PR DESCRIPTION
- edited the 2023 annual event page (and general event page) to reflect the event has passed, and add the recording links
- changed the governance page to reflect that Barbosa has replaced Iacus on the SC